### PR TITLE
support re-use the same response when hitting the same key(method + url)

### DIFF
--- a/response.go
+++ b/response.go
@@ -100,11 +100,15 @@ func NewRespBodyFromBytes(body []byte) io.ReadCloser {
 }
 
 type dummyReadCloser struct {
-	body io.Reader
+	body io.ReadSeeker
 }
 
 func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
-	return d.body.Read(p)
+	n, err = d.body.Read(p)
+	if err == io.EOF {
+		d.body.Seek(0, 0)
+	}
+	return n, err
 }
 
 func (d *dummyReadCloser) Close() error {

--- a/response_test.go
+++ b/response_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io/ioutil"
+	"net/http"
 	"testing"
 )
 
@@ -96,5 +97,43 @@ func TestNewXmlResponse(t *testing.T) {
 
 	if checkBody.Hello != body.Hello {
 		t.FailNow()
+	}
+}
+
+func TestRewindResponse(t *testing.T) {
+	body := []byte("hello world")
+	status := 200
+	responses := []*http.Response{
+		NewBytesResponse(status, body),
+		NewStringResponse(status, string(body)),
+	}
+
+	for _, response := range responses {
+
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(data) != string(body) {
+			t.FailNow()
+		}
+
+		if response.StatusCode != status {
+			t.FailNow()
+		}
+
+		data, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(data) != string(body) {
+			t.FailNow()
+		}
+
+		if response.StatusCode != status {
+			t.FailNow()
+		}
 	}
 }


### PR DESCRIPTION
Current response can only be used once, and further requests will become invalid, so provide a patch to re-use the same response.
