### PR TITLE
Be able to handle non-default http clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
-go: 1.2
+go: tip
 notifications:
     email: false

--- a/transport.go
+++ b/transport.go
@@ -98,6 +98,10 @@ var DefaultTransport = NewMockTransport()
 // when Deactivate is called.
 var InitialTransport = http.DefaultTransport
 
+// Used to handle custom http clients (i.e clients other than http.DefaultClient)
+var oldTransport http.RoundTripper
+var oldClient *http.Client
+
 // Activate starts the mock environment.  This should be called before your tests run.  Under the
 // hood this replaces the Transport on the http.DefaultClient with DefaultTransport.
 //
@@ -125,6 +129,24 @@ func Activate() {
 	http.DefaultTransport = DefaultTransport
 }
 
+// ActivateNonDefault starts the mock environment with a non-default http.Client.
+// This emulates the Activate function, but allows for custom clients that do not use
+// http.DefaultTransport
+//
+// To enable mocks for a test using a custom client, activate at the beginning of a test:
+// 		client := &http.Client{Transport: &http.Transport{TLSHandshakeTimeout: 60 * time.Second}}
+// 		httpmock.ActivateNonDefault(client)
+func ActivateNonDefault(client *http.Client) {
+	if Disabled() {
+		return
+	}
+
+	// save the custom client & it's RoundTripper
+	oldTransport = client.Transport
+	oldClient = client
+	client.Transport = DefaultTransport
+}
+
 // Deactivate shuts down the mock environment.  Any HTTP calls made after this will use a live
 // transport.
 //
@@ -140,6 +162,11 @@ func Deactivate() {
 		return
 	}
 	http.DefaultTransport = InitialTransport
+
+	// reset the custom client to use it's original RoundTripper
+	if oldClient != nil {
+		oldClient.Transport = oldTransport
+	}
 }
 
 // Reset will remove any registered mocks and return the mock environment to it's initial state.

--- a/transport_test.go
+++ b/transport_test.go
@@ -2,9 +2,11 @@ package httpmock
 
 import (
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 var testUrl = "http://www.example.com/"
@@ -137,5 +139,48 @@ func TestMockTransportInitialTransport(t *testing.T) {
 
 	if http.DefaultTransport != tripper {
 		t.Fatal("expected http.DefaultTransport to be dummy")
+	}
+}
+
+func TestMockTransportNonDefault(t *testing.T) {
+	// create a custom http client w/ custom Roundtripper
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   60 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 60 * time.Second,
+		},
+	}
+
+	// activate mocks for the client
+	ActivateNonDefault(client)
+	defer DeactivateAndReset()
+
+	body := "hello world!"
+
+	RegisterResponder("GET", testUrl, NewStringResponder(200, body))
+
+	req, err := http.NewRequest("GET", testUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != body {
+		t.FailNow()
 	}
 }


### PR DESCRIPTION
In order to enable mock testing, we currently replace the `http.DefaultTransport` with the mock transport in the `Activate` function. However, we run into errors when we use clients other than `http.DefaultClient` (which uses the default transport). In order to handle non-default clients, this PR introduces the `ActivateNonDefault` function, which  replaces custom the `http.Transport` with the mock transport for custom `http.Clients`. 

Also bumped travis to the newest version and added a unit test for the new function. 

