### PR TITLE
Made the http.RoundTripper a parameter of Activate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ httpmock [![Build Status](https://travis-ci.org/jarcoal/httpmock.png?branch=mast
 ### Simple Example:
 ```go
 func TestFetchArticles(t *testing.T) {
-	httpmock.Activate()
+	httpmock.Activate(&http.DefaultTransport)
 	defer httpmock.DeactivateAndReset()
 
 	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
@@ -17,7 +17,7 @@ func TestFetchArticles(t *testing.T) {
 ### Advanced Example:
 ```go
 func TestFetchArticles(t *testing.T) {
-	httpmock.Activate()
+	httpmock.Activate(&http.DefaultTransport)
 	defer httpmock.DeactivateAndReset()
 
 	// our database of articles

--- a/env_test.go
+++ b/env_test.go
@@ -19,7 +19,7 @@ func TestEnv(t *testing.T) {
 	}
 
 	// make sure an activation works
-	Activate()
+	Activate(&http.DefaultTransport)
 	if http.DefaultTransport != DefaultTransport {
 		t.Fatal("expected http.DefaultTransport to be our DefaultTransport")
 	}
@@ -32,7 +32,7 @@ func TestEnv(t *testing.T) {
 	}
 
 	// make sure activation doesn't work
-	Activate()
+	Activate(&http.DefaultTransport)
 	if http.DefaultTransport == DefaultTransport {
 		t.Fatal("expected http.DefaultTransport to not be our DefaultTransport")
 	}

--- a/transport.go
+++ b/transport.go
@@ -98,10 +98,6 @@ var DefaultTransport = NewMockTransport()
 // when Deactivate is called.
 var InitialTransport = http.DefaultTransport
 
-// Used to handle custom http clients (i.e clients other than http.DefaultClient)
-var oldTransport http.RoundTripper
-var oldClient *http.Client
-
 // Activate starts the mock environment.  This should be called before your tests run.  Under the
 // hood this replaces the Transport on the http.DefaultClient with DefaultTransport.
 //
@@ -129,24 +125,6 @@ func Activate() {
 	http.DefaultTransport = DefaultTransport
 }
 
-// ActivateNonDefault starts the mock environment with a non-default http.Client.
-// This emulates the Activate function, but allows for custom clients that do not use
-// http.DefaultTransport
-//
-// To enable mocks for a test using a custom client, activate at the beginning of a test:
-// 		client := &http.Client{Transport: &http.Transport{TLSHandshakeTimeout: 60 * time.Second}}
-// 		httpmock.ActivateNonDefault(client)
-func ActivateNonDefault(client *http.Client) {
-	if Disabled() {
-		return
-	}
-
-	// save the custom client & it's RoundTripper
-	oldTransport = client.Transport
-	oldClient = client
-	client.Transport = DefaultTransport
-}
-
 // Deactivate shuts down the mock environment.  Any HTTP calls made after this will use a live
 // transport.
 //
@@ -162,11 +140,6 @@ func Deactivate() {
 		return
 	}
 	http.DefaultTransport = InitialTransport
-
-	// reset the custom client to use it's original RoundTripper
-	if oldClient != nil {
-		oldClient.Transport = oldTransport
-	}
 }
 
 // Reset will remove any registered mocks and return the mock environment to it's initial state.

--- a/transport.go
+++ b/transport.go
@@ -98,6 +98,9 @@ var DefaultTransport = NewMockTransport()
 // when Deactivate is called.
 var InitialTransport = http.DefaultTransport
 
+// PointerToTransport is a pointer to the transport object we want to manipulate
+var PointerToTransport *http.RoundTripper
+
 // Activate starts the mock environment.  This should be called before your tests run.  Under the
 // hood this replaces the Transport on the http.DefaultClient with DefaultTransport.
 //
@@ -111,18 +114,19 @@ var InitialTransport = http.DefaultTransport
 // 		func init() {
 // 			httpmock.Activate()
 // 		}
-func Activate() {
+func Activate(transport *http.RoundTripper) {
 	if Disabled() {
 		return
 	}
 
 	// make sure that if Activate is called multiple times it doesn't overwrite the InitialTransport
 	// with a mock transport.
-	if http.DefaultTransport != DefaultTransport {
-		InitialTransport = http.DefaultTransport
+	if *transport != DefaultTransport {
+		InitialTransport = *transport
+		PointerToTransport = transport
 	}
 
-	http.DefaultTransport = DefaultTransport
+	*transport = DefaultTransport
 }
 
 // Deactivate shuts down the mock environment.  Any HTTP calls made after this will use a live
@@ -139,7 +143,9 @@ func Deactivate() {
 	if Disabled() {
 		return
 	}
-	http.DefaultTransport = InitialTransport
+	if PointerToTransport != nil {
+		*PointerToTransport = InitialTransport
+	}
 }
 
 // Reset will remove any registered mocks and return the mock environment to it's initial state.

--- a/transport_test.go
+++ b/transport_test.go
@@ -2,11 +2,9 @@ package httpmock
 
 import (
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 )
 
 var testUrl = "http://www.example.com/"
@@ -139,48 +137,5 @@ func TestMockTransportInitialTransport(t *testing.T) {
 
 	if http.DefaultTransport != tripper {
 		t.Fatal("expected http.DefaultTransport to be dummy")
-	}
-}
-
-func TestMockTransportNonDefault(t *testing.T) {
-	// create a custom http client w/ custom Roundtripper
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   60 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: 60 * time.Second,
-		},
-	}
-
-	// activate mocks for the client
-	ActivateNonDefault(client)
-	defer DeactivateAndReset()
-
-	body := "hello world!"
-
-	RegisterResponder("GET", testUrl, NewStringResponder(200, body))
-
-	req, err := http.NewRequest("GET", testUrl, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(data) != body {
-		t.FailNow()
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -10,7 +10,7 @@ import (
 var testUrl = "http://www.example.com/"
 
 func TestMockTransport(t *testing.T) {
-	Activate()
+	Activate(&http.DefaultTransport)
 	defer Deactivate()
 
 	url := "https://github.com/"
@@ -62,7 +62,7 @@ func TestMockTransportReset(t *testing.T) {
 }
 
 func TestMockTransportNoResponder(t *testing.T) {
-	Activate()
+	Activate(&http.DefaultTransport)
 	defer DeactivateAndReset()
 
 	Reset()
@@ -93,7 +93,7 @@ func TestMockTransportNoResponder(t *testing.T) {
 }
 
 func TestMockTransportQuerystringFallback(t *testing.T) {
-	Activate()
+	Activate(&http.DefaultTransport)
 	defer DeactivateAndReset()
 
 	// register the testUrl responder
@@ -127,7 +127,7 @@ func TestMockTransportInitialTransport(t *testing.T) {
 	tripper := &dummyTripper{}
 	http.DefaultTransport = tripper
 
-	Activate()
+	Activate(&http.DefaultTransport)
 
 	if http.DefaultTransport == tripper {
 		t.Fatal("expected http.DefaultTransport to be a mock transport")


### PR DESCRIPTION
I only just saw the latest changes adding in ActivateNonDefault()  function with the http.Client.

I guess i'm a bit late to the party here but my solution is slightly cleaner, i took into account appengine/urlfetch which doesn't use the http.DefaultTransport. 

The ActivateNonDefault() does work too, but i find it more cumbersome.

I missed the debate but i'm just proposing this as an alternative albeit slightly too late.
