### PR TITLE
Enable to work with goquery

### DIFF
--- a/response.go
+++ b/response.go
@@ -13,7 +13,10 @@ import (
 // ResponderFromResponse wraps an *http.Response in a Responder
 func ResponderFromResponse(resp *http.Response) Responder {
 	return func(req *http.Request) (*http.Response, error) {
-		return resp, nil
+		res := new(http.Response)
+		*res = *resp
+		res.Request = req
+		return res, nil
 	}
 }
 


### PR DESCRIPTION
## Problem

httpmock doesn't work with goquery.
https://github.com/PuerkitoBio/goquery
## Code example
- `main.go`

``` go
package main

import (
    "github.com/PuerkitoBio/goquery"
    "github.com/jarcoal/httpmock"
)

func main() {
    httpmock.Activate()
    defer httpmock.DeactivateAndReset()
    httpmock.RegisterResponder("GET", "https://google.com",
        httpmock.NewStringResponder(200, ""))
    _, err := goquery.NewDocument("https://google.com")
    if err != nil {
        panic(err)
    }
}
```

``` sh
$ go run main.go
panic: Response.Request is nil

goroutine 1 [running]:
main.main()
    /tmp/twarfhesuif/main.go:15 +0x1b3

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
    /usr/lib/go/src/runtime/asm_amd64.s:1696 +0x1
exit status 2
```
## Cause

https://github.com/PuerkitoBio/goquery/blob/master/type.go#L63

goquery checks `Response.Request`.
