### PR TITLE
Add ContentLength property in mocked http.Response

### DIFF
--- a/response.go
+++ b/response.go
@@ -21,10 +21,11 @@ func ResponderFromResponse(resp *http.Response) Responder {
 // an http status code.
 func NewStringResponse(status int, body string) *http.Response {
 	return &http.Response{
-		Status:     strconv.Itoa(status),
-		StatusCode: status,
-		Body:       NewRespBodyFromString(body),
-		Header:     http.Header{},
+		Status:        strconv.Itoa(status),
+		StatusCode:    status,
+		Body:          NewRespBodyFromString(body),
+		Header:        http.Header{},
+		ContentLength: -1,
 	}
 }
 
@@ -37,10 +38,11 @@ func NewStringResponder(status int, body string) Responder {
 // an http status code.
 func NewBytesResponse(status int, body []byte) *http.Response {
 	return &http.Response{
-		Status:     strconv.Itoa(status),
-		StatusCode: status,
-		Body:       NewRespBodyFromBytes(body),
-		Header:     http.Header{},
+		Status:        strconv.Itoa(status),
+		StatusCode:    status,
+		Body:          NewRespBodyFromBytes(body),
+		Header:        http.Header{},
+		ContentLength: -1,
 	}
 }
 


### PR DESCRIPTION
When using `httpmock` with [`grequests`](https://github.com/levigross/grequests) http client, the `grequests.Response.String()` method will fail to read http response body because the property `ContentLength` of the mocked http.Response is `0`.  (When `ContentLength == 0`, grequests doesn't copy http response body to its own Response, refer to [here](https://github.com/levigross/grequests/blob/a76c2fb61a838cf1a206c4f1ef6c96eccf9cac99/response.go#L162))

According to the [godoc](https://golang.org/pkg/net/http/#Response) of `http.Response`, I think make it as `-1` would be good.

> // ContentLength records the length of the associated content. The
> // value -1 indicates that the length is unknown. Unless Request.Method
> // is "HEAD", values >= 0 indicate that the given number of bytes may
> // be read from Body.

thanks :)
