### PR TITLE
Add Error Responder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.6
   - 1.7
-  - tip
 
 notifications:
   email: false

--- a/response.go
+++ b/response.go
@@ -20,6 +20,15 @@ func ResponderFromResponse(resp *http.Response) Responder {
 	}
 }
 
+// NewErrorResponder creates a Responder that returns an empty request and the
+// given error. This can be used to e.g. imitate more deep http errors for the
+// client.
+func NewErrorResponder(err error) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return nil, err
+	}
+}
+
 // NewStringResponse creates an *http.Response with a body based on the given string.  Also accepts
 // an http status code.
 func NewStringResponse(status int, body string) *http.Response {

--- a/response_test.go
+++ b/response_test.go
@@ -3,8 +3,10 @@ package httpmock
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -16,6 +18,9 @@ func TestResponderFromResponse(t *testing.T) {
 		t.Fatal("Error creating request")
 	}
 	response1, err := responder(req)
+	if err != nil {
+		t.Error("Error should be nil")
+	}
 
 	testUrlWithQuery := testUrl + "?a=1"
 	req, err = http.NewRequest(http.MethodGet, testUrlWithQuery, nil)
@@ -23,6 +28,9 @@ func TestResponderFromResponse(t *testing.T) {
 		t.Fatal("Error creating request")
 	}
 	response2, err := responder(req)
+	if err != nil {
+		t.Error("Error should be nil")
+	}
 
 	// Body should be the same for both responses
 	assertBody(t, response1, "hello world")
@@ -138,6 +146,22 @@ func TestNewXmlResponse(t *testing.T) {
 
 	if checkBody.Hello != body.Hello {
 		t.FailNow()
+	}
+}
+
+func TestNewErrorResponder(t *testing.T) {
+	responder := NewErrorResponder(errors.New("oh no"))
+	req, err := http.NewRequest(http.MethodGet, testUrl, nil)
+	if err != nil {
+		t.Fatal("Error creating request")
+	}
+	response, err := responder(req)
+	if response != nil {
+		t.Error("Response should be nil")
+	}
+	expected := errors.New("oh no")
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("Expected error %#v, got: %#v", expected, err)
 	}
 }
 


### PR DESCRIPTION
This commit adds a new responder that returns a custom error and an
empty response.