### PR TITLE
add call count support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ func TestFetchArticles(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
 		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
 
+  // get count info
+  httpmock.GetTotalCallCount()
+
+  // get the amount of calls for the registered responder
+  info := httpmock.GetCallCountInfo()
+  info["GET https://api.mybiz.com/articles.json"] // number of GET calls made to https://api.mybiz.com/articles.json
+
 	// do stuff that makes a request to articles.json
 }
 ```

--- a/transport_test.go
+++ b/transport_test.go
@@ -345,7 +345,7 @@ func TestMockTransportCallCount(t *testing.T) {
 	Reset()
 
 	afterResetTotalCallCount := GetTotalCallCount()
-	if totalCallCount != 3 {
+	if afterResetTotalCallCount != 0 {
 		t.Fatalf("did not reset the total count of calls correctly. expected it to be 0 after reset, but it was %v", afterResetTotalCallCount)
 	}
 


### PR DESCRIPTION
I'd like to use call counts in my tests to see the number calls that I have made to a specific URL and method. This is helpful to do a quick verification that I actually did call a URL or URLs and how many times I called them. It adds two new methods `GetTotalCallCount` that returns the total call count since the last reset and `GetCallCountInfo` which returns call counts for specific URL-method combos.