### PR TITLE
Can register URL path only as last fallback before failure

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -55,6 +55,14 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		key = req.Method + " " + strings.Split(url, "?")[0]
 		responder = m.responderForKey(key)
 	}
+
+	// if we weren't able to find a responder for the full URL, try with
+	// the path only
+	if responder == nil {
+		key = req.Method + " " + req.URL.Path
+		responder = m.responderForKey(key)
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// if we found a responder, call it

--- a/transport_test.go
+++ b/transport_test.go
@@ -137,6 +137,29 @@ func TestMockTransportQuerystringFallback(t *testing.T) {
 	}
 }
 
+func TestMockTransportPathOnlyFallback(t *testing.T) {
+	Activate()
+	defer DeactivateAndReset()
+
+	// register the URL path only responder
+	RegisterResponder("GET", "/hello/world", NewStringResponder(200, "hello world"))
+
+	// make a request for the testUrl with a path
+	resp, err := http.Get(testUrl + "hello/world")
+	if err != nil {
+		t.Fatal("expected request to succeed")
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != "hello world" {
+		t.Fatal("expected body to be 'hello world'")
+	}
+}
+
 type dummyTripper struct{}
 
 func (d *dummyTripper) RoundTrip(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
Useful when the scheme+host are hidden behind some cryptic SDK