### PR TITLE
MockTransport.RoundTrip() URL handling reworked & more robust

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -121,42 +121,70 @@ func TestMockTransportQuerystringFallback(t *testing.T) {
 	// register the testUrl responder
 	RegisterResponder("GET", testUrl, NewStringResponder(200, "hello world"))
 
-	// make a request for the testUrl with a querystring
-	resp, err := http.Get(testUrl + "?hello=world")
-	if err != nil {
-		t.Fatal("expected request to succeed")
-	}
+	for _, suffix := range []string{"?", "?hello=world", "?hello=world#foo", "#foo"} {
+		reqURL := testUrl + suffix
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
+		// make a request for the testUrl with a querystring
+		resp, err := http.Get(reqURL)
+		if err != nil {
+			t.Fatalf("expected request %s to succeed", reqURL)
+		}
 
-	if string(data) != "hello world" {
-		t.Fatal("expected body to be 'hello world'")
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("%s error: %s", reqURL, err)
+		}
+
+		if string(data) != "hello world" {
+			t.Fatalf("expected body of %s to be 'hello world'", reqURL)
+		}
 	}
 }
 
 func TestMockTransportPathOnlyFallback(t *testing.T) {
-	Activate()
+	// Just in case a panic occurs
 	defer DeactivateAndReset()
 
-	// register the URL path only responder
-	RegisterResponder("GET", "/hello/world", NewStringResponder(200, "hello world"))
+	for responder, paths := range map[string][]string{
+		"/hello/world?query=string#fragment": {
+			testUrl + "hello/world?query=string#fragment",
+		},
+		"/hello/world?query=string": {
+			testUrl + "hello/world?query=string",
+		},
+		"/hello/world#fragment": {
+			testUrl + "hello/world#fragment",
+		},
+		"/hello/world": {
+			testUrl + "hello/world?query=string#fragment",
+			testUrl + "hello/world?query=string",
+			testUrl + "hello/world#fragment",
+			testUrl + "hello/world",
+		},
+	} {
+		Activate()
 
-	// make a request for the testUrl with a path
-	resp, err := http.Get(testUrl + "hello/world")
-	if err != nil {
-		t.Fatal("expected request to succeed")
-	}
+		// register the responder
+		RegisterResponder("GET", responder, NewStringResponder(200, "hello world"))
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
+		for _, reqURL := range paths {
+			// make a request for the testUrl with a querystring
+			resp, err := http.Get(reqURL)
+			if err != nil {
+				t.Fatalf("%s: expected request %s to succeed", responder, reqURL)
+			}
 
-	if string(data) != "hello world" {
-		t.Fatal("expected body to be 'hello world'")
+			data, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("%s: %s error: %s", responder, reqURL, err)
+			}
+
+			if string(data) != "hello world" {
+				t.Fatalf("%s: expected body of %s to be 'hello world'", responder, reqURL)
+			}
+		}
+
+		DeactivateAndReset()
 	}
 }
 


### PR DESCRIPTION
- do not rely on Split("?") anymore

- fragment part (if present) is handled as query string (was not
  stripped in query string fallback, when there was no query string)

- path only fallback now tries with query string then without (was
  only without query string)

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>