### PR TITLE
Fix finding responders for Requests with an empty .Method

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -45,8 +45,14 @@ type MockTransport struct {
 func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	url := req.URL.String()
 
+	method := req.Method
+	if method == "" {
+		// http.Request.Method is documented to default to GET:
+		method = http.MethodGet
+	}
+
 	// try and get a responder that matches the method and URL
-	key := req.Method + " " + url
+	key := method + " " + url
 	responder := m.responderForKey(key)
 
 	// if we weren't able to find a responder
@@ -64,14 +70,14 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// if the URL contains a querystring then we strip off the
 		// querystring and try again.
 		if hasQueryString {
-			key = req.Method + " " + surl
+			key = method + " " + surl
 			responder = m.responderForKey(key)
 		}
 
 		// if we weren't able to find a responder for the full URL, try with
 		// the path part only
 		if responder == nil {
-			keyPathAlone := req.Method + " " + req.URL.Path
+			keyPathAlone := method + " " + req.URL.Path
 			key = keyPathAlone
 
 			// First with querystring

--- a/transport_test.go
+++ b/transport_test.go
@@ -63,6 +63,43 @@ func TestMockTransport(t *testing.T) {
 	}
 }
 
+// We should be able to find GET handlers when using an http.Request with a
+// default (zero-value) .Method.
+func TestMockTransportDefaultMethod(t *testing.T) {
+	Activate()
+	defer Deactivate()
+
+	urlString := "https://github.com/"
+	url, err := url.Parse(urlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := "hello world"
+
+	RegisterResponder("GET", urlString, NewStringResponder(200, body))
+
+	req := &http.Request {
+		URL: url,
+		// Note: Method unspecified (zero-value)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != body {
+		t.FailNow()
+	}
+}
+
 func TestMockTransportReset(t *testing.T) {
 	DeactivateAndReset()
 


### PR DESCRIPTION
This addresses issue #47.