### PR TITLE
Fix wrong argument order in RegisterResponder example

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -190,7 +190,7 @@ func DeactivateAndReset() {
 // 			httpmock.DeactivateAndReset()
 //
 // 			httpmock.RegisterResponder("GET", "http://example.com/",
-// 				httpmock.NewStringResponder("hello world", 200))
+// 				httpmock.NewStringResponder(200, "hello world"))
 //
 //			// requests to http://example.com/ will now return 'hello world'
 // 		}


### PR DESCRIPTION
## What
Fix wrong argument order in `RegisterResponder` example.

## Why
When I saw [godoc](https://godoc.org/github.com/jarcoal/httpmock#RegisterResponder), I was a little bit confused because the `RegisterResponder` example is : 

```go
func TestFetchArticles(t *testing.T) {
	...

	httpmock.RegisterResponder("GET", "http://example.com/",
		httpmock.NewStringResponder("hello world", 200))
        
        ...
}
```

but [NewStringResponder](https://godoc.org/github.com/jarcoal/httpmock#NewStringResponder) is : 

```go
func NewStringResponder(status int, body string) Responder
```