### PR TITLE
Splitting duplicate query parameters

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -201,8 +201,9 @@ func (m *MockTransport) RegisterResponderWithQuery(method, path string, query ma
 	url := path
 	mapQuery := make(map[string][]string, len(query))
 	for key, e := range query {
-		mapQuery[key] = []string{e}
+		mapQuery[key] = strings.Split(e, " ")
 	}
+
 	queryString := mapToSortedQuery(mapQuery)
 	if queryString != nil {
 		url = path + "?" + *queryString


### PR DESCRIPTION
Use case: you have query parameters with duplicate keys and you want to use the method `httpmock.RegisterResponderWithQuery`. Because the query is a map you cannot add duplicate keys. You could work around this by adding a map value like this: `"key": "a b"`. However, mapQuery is currently not setup for this. You could do a split on white spaces in order to allow duplicate query keys.  

^ @Zanadar this is an addition to your fix #55 - this does not appear to solve our issue with duplicate query parameters (or I could be making a mistake). Ideas? :) 