### PR TITLE
dummyReadCloser: Seek(0, 0) when Close() is called explicitely

### DIFF
--- a/response.go
+++ b/response.go
@@ -166,5 +166,6 @@ func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
 }
 
 func (d *dummyReadCloser) Close() error {
+	d.body.Seek(0, 0)
 	return nil
 }


### PR DESCRIPTION
as it is already the case when io.EOF is encountered.

encoding/json decoder, for example, stops reading at the end of
the JSON message so before EOF is reached.

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>