### PR TITLE
If several non-default clients are activated, correctly disable them

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -337,8 +337,7 @@ var DefaultTransport = NewMockTransport()
 var InitialTransport = http.DefaultTransport
 
 // Used to handle custom http clients (i.e clients other than http.DefaultClient)
-var oldTransport http.RoundTripper
-var oldClient *http.Client
+var oldClients = map[*http.Client]http.RoundTripper{}
 
 // Activate starts the mock environment.  This should be called before your tests run.  Under the
 // hood this replaces the Transport on the http.DefaultClient with DefaultTransport.
@@ -380,8 +379,9 @@ func ActivateNonDefault(client *http.Client) {
 	}
 
 	// save the custom client & it's RoundTripper
-	oldTransport = client.Transport
-	oldClient = client
+	if _, ok := oldClients[client]; !ok {
+		oldClients[client] = client.Transport
+	}
 	client.Transport = DefaultTransport
 }
 
@@ -414,9 +414,10 @@ func Deactivate() {
 	}
 	http.DefaultTransport = InitialTransport
 
-	// reset the custom client to use it's original RoundTripper
-	if oldClient != nil {
+	// reset the custom clients to use their original RoundTripper
+	for oldClient, oldTransport := range oldClients {
 		oldClient.Transport = oldTransport
+		delete(oldClients, oldClient)
 	}
 }
 


### PR DESCRIPTION
Deactivate() only re-enabled last ActivateNonDefault()'ed client. Previous ones stayed "Activated". Now Deactivate re-enables all ActivateNonDefault()'ed clients.