### PR TITLE
Add regexp responders feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - go test -race -covermode=atomic -coverprofile=coverage.out ./...
   - >
     if [ "$USE_LINTER" = 1 ]; then
-      golangci-lint run -E gofmt -E golint -E maligned -E prealloc -E unconvert ./...;
+      golangci-lint run -E gofmt -E golint -E maligned -E misspell -E prealloc -E unconvert ./...;
     fi
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# httpmock [![Build Status](https://travis-ci.org/jarcoal/httpmock.png?branch=v1)](https://travis-ci.org/jarcoal/httpmock) [![Coverage Status](https://coveralls.io/repos/github/jarcoal/httpmock/badge.svg?branch=v1)](https://coveralls.io/github/jarcoal/httpmock?branch=v1) [![GoDoc](https://godoc.org/github.com/jarcoal/httpmock?status.svg)](https://godoc.org/github.com/jarcoal/httpmock) [![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/jarcoal/httpmock/releases)
+# httpmock [![Build Status](https://travis-ci.org/jarcoal/httpmock.png?branch=v1)](https://travis-ci.org/jarcoal/httpmock) [![Coverage Status](https://coveralls.io/repos/github/jarcoal/httpmock/badge.svg?branch=v1)](https://coveralls.io/github/jarcoal/httpmock?branch=v1) [![GoDoc](https://godoc.org/github.com/jarcoal/httpmock?status.svg)](https://godoc.org/github.com/jarcoal/httpmock) [![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/jarcoal/httpmock/releases) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go/#testing)
 
 Easy mocking of http responses from external resources.
 
@@ -107,6 +107,18 @@ func TestFetchArticles(t *testing.T) {
 				return httpmock.NewStringResponse(500, ""), nil
 			}
 			return resp, nil
+		},
+	)
+
+	// return an article related to the request with the help of regexp submatch (\d+)
+	httpmock.RegisterResponder("GET", `=~^https://api.mybiz.com/articles/id/(\d+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			// Get ID from request
+			id := httpmock.MustGetSubmatchAsUint(req, 1) // 1=first regexp submatch
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				"id":   id,
+				"name": "My Great Article",
+			})
 		},
 	)
 

--- a/transport.go
+++ b/transport.go
@@ -6,14 +6,31 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 )
 
+const regexpPrefix = "=~"
+
 // NoResponderFound is returned when no responders are found for a given HTTP method and URL.
 var NoResponderFound = errors.New("no responder found") // nolint: golint
+
+type routeKey struct {
+	Method string
+	URL    string
+}
+
+var noResponder routeKey
+
+func (r routeKey) String() string {
+	if r == noResponder {
+		return "NO_RESPONDER"
+	}
+	return r.Method + " " + r.URL
+}
 
 // ConnectionFailure is a responder that returns a connection failure.  This is the default
 // responder, and is called when no other matching responder is found.
@@ -24,20 +41,28 @@ func ConnectionFailure(*http.Request) (*http.Response, error) {
 // NewMockTransport creates a new *MockTransport with no responders.
 func NewMockTransport() *MockTransport {
 	return &MockTransport{
-		responders:    make(map[string]Responder),
-		callCountInfo: make(map[string]int),
+		responders:    make(map[routeKey]Responder),
+		callCountInfo: make(map[routeKey]int),
 	}
+}
+
+type regexpResponder struct {
+	origRx    string
+	method    string
+	rx        *regexp.Regexp
+	responder Responder
 }
 
 // MockTransport implements http.RoundTripper, which fulfills single http requests issued by
 // an http.Client.  This implementation doesn't actually make the call, instead deferring to
 // the registered list of responders.
 type MockTransport struct {
-	mu             sync.RWMutex
-	responders     map[string]Responder
-	noResponder    Responder
-	callCountInfo  map[string]int
-	totalCallCount int
+	mu               sync.RWMutex
+	responders       map[routeKey]Responder
+	regexpResponders []regexpResponder
+	noResponder      Responder
+	callCountInfo    map[routeKey]int
+	totalCallCount   int
 }
 
 // RoundTrip receives HTTP requests and routes them to the appropriate responder.  It is required to
@@ -52,25 +77,37 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		method = http.MethodGet
 	}
 
-	// try and get a responder that matches the method and URL with
-	// query params untouched: http://z.tld/path?q...
-	key := method + " " + url
-	responder := m.responderForKey(key)
+	var responder Responder
+	var respKey routeKey
+	key := routeKey{
+		Method: method,
+	}
+	for _, getResponder := range []func(routeKey) (Responder, routeKey){
+		m.responderForKey,       // Exact match
+		m.regexpResponderForKey, // Regexp match
+	} {
+		// try and get a responder that matches the method and URL with
+		// query params untouched: http://z.tld/path?q...
+		key.URL = url
+		responder, respKey = getResponder(key)
+		if responder != nil {
+			break
+		}
 
-	// if we weren't able to find a responder, try with the URL *and*
-	// sorted query params
-	if responder == nil {
+		// if we weren't able to find a responder, try with the URL *and*
+		// sorted query params
 		query := sortedQuery(req.URL.Query())
 		if query != "" {
 			// Replace unsorted query params by sorted ones:
 			//   http://z.tld/path?sorted_q...
-			key = method + " " + strings.Replace(url, req.URL.RawQuery, query, 1)
-			responder = m.responderForKey(key)
+			key.URL = strings.Replace(url, req.URL.RawQuery, query, 1)
+			responder, respKey = getResponder(key)
+			if responder != nil {
+				break
+			}
 		}
-	}
 
-	// if we weren't able to find a responder, try without any query params
-	if responder == nil {
+		// if we weren't able to find a responder, try without any query params
 		strippedURL := *req.URL
 		strippedURL.RawQuery = ""
 		strippedURL.Fragment = ""
@@ -84,35 +121,41 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// if the URL contains a querystring then we strip off the
 		// querystring and try again: http://z.tld/path
 		if hasQueryString {
-			key = method + " " + surl
-			responder = m.responderForKey(key)
+			key.URL = surl
+			responder, respKey = getResponder(key)
+			if responder != nil {
+				break
+			}
 		}
 
 		// if we weren't able to find a responder for the full URL, try with
 		// the path part only
-		if responder == nil {
-			keyPathAlone := method + " " + req.URL.Path
+		pathAlone := req.URL.Path
 
-			// First with unsorted querystring: /path?q...
-			if hasQueryString {
-				key = keyPathAlone + strings.TrimPrefix(url, surl) // concat after-path part
-				responder = m.responderForKey(key)
-
-				// Then with sorted querystring: /path?sorted_q...
-				if responder == nil {
-					key = keyPathAlone + "?" + sortedQuery(req.URL.Query())
-					if req.URL.Fragment != "" {
-						key += "#" + req.URL.Fragment
-					}
-					responder = m.responderForKey(key)
-				}
+		// First with unsorted querystring: /path?q...
+		if hasQueryString {
+			key.URL = pathAlone + strings.TrimPrefix(url, surl) // concat after-path part
+			responder, respKey = getResponder(key)
+			if responder != nil {
+				break
 			}
 
-			// Then using path alone: /path
-			if responder == nil {
-				key = keyPathAlone
-				responder = m.responderForKey(key)
+			// Then with sorted querystring: /path?sorted_q...
+			key.URL = pathAlone + "?" + sortedQuery(req.URL.Query())
+			if req.URL.Fragment != "" {
+				key.URL += "#" + req.URL.Fragment
 			}
+			responder, respKey = getResponder(key)
+			if responder != nil {
+				break
+			}
+		}
+
+		// Then using path alone: /path
+		key.URL = pathAlone
+		responder, respKey = getResponder(key)
+		if responder != nil {
+			break
 		}
 	}
 
@@ -120,11 +163,14 @@ func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// if we found a responder, call it
 	if responder != nil {
 		m.callCountInfo[key]++
+		if key != respKey {
+			m.callCountInfo[respKey]++
+		}
 		m.totalCallCount++
 	} else {
 		// we didn't find a responder, so fire the 'no responder' responder
 		if m.noResponder != nil {
-			m.callCountInfo["NO_RESPONDER"]++
+			m.callCountInfo[noResponder]++
 			m.totalCallCount++
 			responder = m.noResponder
 		}
@@ -275,10 +321,29 @@ func checkStackTracer(req *http.Request, err error) error {
 }
 
 // responderForKey returns a responder for a given key.
-func (m *MockTransport) responderForKey(key string) Responder {
+func (m *MockTransport) responderForKey(key routeKey) (Responder, routeKey) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.responders[key]
+	return m.responders[key], key
+}
+
+// responderForKeyUsingRegexp returns the first responder matching a given key using regexps.
+func (m *MockTransport) regexpResponderForKey(key routeKey) (Responder, routeKey) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, regInfo := range m.regexpResponders {
+		if regInfo.method == key.Method && regInfo.rx.MatchString(key.URL) {
+			return regInfo.responder, routeKey{
+				Method: key.Method,
+				URL:    regInfo.origRx,
+			}
+		}
+	}
+	return nil, key
+}
+
+func isRegexpURL(url string) bool {
+	return strings.HasPrefix(url, regexpPrefix)
 }
 
 // RegisterResponder adds a new responder, associated with a given
@@ -287,9 +352,56 @@ func (m *MockTransport) responderForKey(key string) Responder {
 // When a request comes in that matches, the responder will be called
 // and the response returned to the client.
 //
-// If url contains query parameters, their order matters.
+// If url contains query parameters, their order matters as well as
+// their content. All following URLs are here considered as different:
+//   http://z.tld?a=1&b=1
+//   http://z.tld?b=1&a=1
+//   http://z.tld?a&b
+//   http://z.tld?a=&b=
+//
+// If url begins with "=~", the following chars are considered as a
+// regular expression. If this regexp can not be compiled, it panics.
+// Note that the "=~" prefix remains in statistics returned by
+// GetCallCountInfo(). As 2 regexps can match the same URL, the regexp
+// responders are tested in the order they are registered. Registering
+// an already existing regexp responder (same method & same regexp
+// string) replaces its responder but does not change its position.
+//
+// See RegisterRegexpResponder() to directly pass a *regexp.Regexp.
+//
+// Example:
+// 		func TestFetchArticles(t *testing.T) {
+// 			httpmock.Activate()
+// 			defer httpmock.DeactivateAndReset()
+//
+// 			httpmock.RegisterResponder("GET", "http://example.com/",
+// 				httpmock.NewStringResponder(200, "hello world"))
+//
+// 			httpmock.RegisterResponder("GET", "/path/only",
+// 				httpmock.NewStringResponder("any host hello world", 200))
+//
+// 			httpmock.RegisterResponder("GET", `=~^/item/id/\d+\z`,
+// 				httpmock.NewStringResponder("any item get", 200))
+//
+//			// requests to http://example.com/ will now return "hello world" and
+//			// requests to any host with path /path/only will return "any host hello world"
+//			// requests to any host with path matching ^/item/id/\d+\z regular expression will return "any item get"
+// 		}
 func (m *MockTransport) RegisterResponder(method, url string, responder Responder) {
-	key := method + " " + url
+	if isRegexpURL(url) {
+		m.registerRegexpResponder(regexpResponder{
+			origRx:    url,
+			method:    method,
+			rx:        regexp.MustCompile(url[2:]),
+			responder: responder,
+		})
+		return
+	}
+
+	key := routeKey{
+		Method: method,
+		URL:    url,
+	}
 
 	m.mu.Lock()
 	m.responders[key] = responder
@@ -297,17 +409,71 @@ func (m *MockTransport) RegisterResponder(method, url string, responder Responde
 	m.mu.Unlock()
 }
 
+func (m *MockTransport) registerRegexpResponder(regexpResponder regexpResponder) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+found:
+	for {
+		for i, rr := range m.regexpResponders {
+			if rr.method == regexpResponder.method && rr.origRx == regexpResponder.origRx {
+				m.regexpResponders[i] = regexpResponder
+				break found
+			}
+		}
+		m.regexpResponders = append(m.regexpResponders, regexpResponder)
+		break // nolint: staticcheck
+	}
+
+	m.callCountInfo[routeKey{
+		Method: regexpResponder.method,
+		URL:    regexpResponder.origRx,
+	}] = 0
+}
+
+// RegisterRegexpResponder adds a new responder, associated with a given
+// HTTP method and URL (or path) regular expression.
+//
+// When a request comes in that matches, the responder will be called
+// and the response returned to the client.
+//
+// As 2 regexps can match the same URL, the regexp responders are
+// tested in the order they are registered. Registering an already
+// existing regexp responder (same method & same regexp string)
+// replaces its responder but does not change its position.
+//
+// A "=~" prefix is added to the stringified regexp in the statistics
+// returned by GetCallCountInfo().
+//
+// See RegisterResponder function and the "=~" prefix in its url
+// parameter to avoid compiling the regexp by yourself.
+func (m *MockTransport) RegisterRegexpResponder(method string, urlRegexp *regexp.Regexp, responder Responder) {
+	m.registerRegexpResponder(regexpResponder{
+		origRx:    regexpPrefix + urlRegexp.String(),
+		method:    method,
+		rx:        urlRegexp,
+		responder: responder,
+	})
+}
+
 // RegisterResponderWithQuery is same as RegisterResponder, but it
 // doesn't depend on query items order.
 //
-// query type can be:
+// If query is non-nil, its type can be:
 //   url.Values
 //   map[string]string
 //   string, a query string like "a=12&a=13&b=z&c" (see net/url.ParseQuery function)
 //
 // If the query type is not recognized or the string cannot be parsed
 // using net/url.ParseQuery, a panic() occurs.
+//
+// Unlike RegisterResponder, path cannot be prefixed by "=~" to say it
+// is a regexp. If it is, a panic occurs.
 func (m *MockTransport) RegisterResponderWithQuery(method, path string, query interface{}, responder Responder) {
+	if isRegexpURL(path) {
+		panic(`path begins with "=~", RegisterResponder should be used instead of RegisterResponderWithQuery`)
+	}
+
 	var mapQuery url.Values
 	switch q := query.(type) {
 	case url.Values:
@@ -327,7 +493,9 @@ func (m *MockTransport) RegisterResponderWithQuery(method, path string, query in
 		}
 
 	default:
-		panic(fmt.Sprintf("RegisterResponderWithQuery bad query type %T. Only url.Values, map[string]string and string are allowed", query))
+		if query != nil {
+			panic(fmt.Sprintf("RegisterResponderWithQuery bad query type %T. Only url.Values, map[string]string and string are allowed", query))
+		}
 	}
 
 	if queryString := sortedQuery(mapQuery); queryString != "" {
@@ -381,25 +549,42 @@ func (m *MockTransport) RegisterNoResponder(responder Responder) {
 // Reset removes all registered responders (including the no responder) from the MockTransport
 func (m *MockTransport) Reset() {
 	m.mu.Lock()
-	m.responders = make(map[string]Responder)
+	m.responders = make(map[routeKey]Responder)
+	m.regexpResponders = nil
 	m.noResponder = nil
-	m.callCountInfo = make(map[string]int)
+	m.callCountInfo = make(map[routeKey]int)
 	m.totalCallCount = 0
 	m.mu.Unlock()
 }
 
-// GetCallCountInfo returns callCountInfo
+// GetCallCountInfo gets the info on all the calls httpmock has caught
+// since it was activated or reset. The info is returned as a map of
+// the calling keys with the number of calls made to them as their
+// value. The key is the method, a space, and the url all concatenated
+// together.
+//
+// As a special case, regexp responders generate 2 entries for each
+// call. One for the call caught and the other for the rule that
+// matched. For example:
+//   RegisterResponder("GET", `=~z\.com\z`, NewStringResponder(200, "body"))
+//   http.Get("http://z.com")
+//
+// will generate the following result:
+//   map[string]int{
+//     `GET http://z.com`:  1,
+//     `GET =~z\.com\z`: 1,
+//   }
 func (m *MockTransport) GetCallCountInfo() map[string]int {
-	res := map[string]int{}
+	res := make(map[string]int, len(m.callCountInfo))
 	m.mu.RLock()
 	for k, v := range m.callCountInfo {
-		res[k] = v
+		res[k.String()] = v
 	}
 	m.mu.RUnlock()
 	return res
 }
 
-// GetTotalCallCount returns the totalCallCount
+// GetTotalCallCount returns the totalCallCount.
 func (m *MockTransport) GetTotalCallCount() int {
 	m.mu.RLock()
 	count := m.totalCallCount
@@ -464,9 +649,23 @@ func ActivateNonDefault(client *http.Client) {
 	client.Transport = DefaultTransport
 }
 
-// GetCallCountInfo gets the info on all the calls httpmock has taken since it was activated or
-// reset. The info is returned as a map of the calling keys with the number of calls made to them
-// as their value. The key is the method, a space, and the url all concatenated together.
+// GetCallCountInfo gets the info on all the calls httpmock has caught
+// since it was activated or reset. The info is returned as a map of
+// the calling keys with the number of calls made to them as their
+// value. The key is the method, a space, and the url all concatenated
+// together.
+//
+// As a special case, regexp responders generate 2 entries for each
+// call. One for the call caught and the other for the rule that
+// matched. For example:
+//   RegisterResponder("GET", `=~z\.com\z`, NewStringResponder(200, "body"))
+//   http.Get("http://z.com")
+//
+// will generate the following result:
+//   map[string]int{
+//     `GET http://z.com`:  1,
+//     `GET =~z\.com\z`: 1,
+//   }
 func GetCallCountInfo() map[string]int {
 	return DefaultTransport.GetCallCountInfo()
 }
@@ -512,8 +711,28 @@ func DeactivateAndReset() {
 	Reset()
 }
 
-// RegisterResponder adds a mock that will catch requests to the given HTTP method and URL (or path), then
-// route them to the Responder which will generate a response to be returned to the client.
+// RegisterResponder adds a new responder, associated with a given
+// HTTP method and URL (or path).
+//
+// When a request comes in that matches, the responder will be called
+// and the response returned to the client.
+//
+// If url contains query parameters, their order matters as well as
+// their content. All following URLs are here considered as different:
+//   http://z.tld?a=1&b=1
+//   http://z.tld?b=1&a=1
+//   http://z.tld?a&b
+//   http://z.tld?a=&b=
+//
+// If url begins with "=~", the following chars are considered as a
+// regular expression. If this regexp can not be compiled, it panics.
+// Note that the "=~" prefix remains in statistics returned by
+// GetCallCountInfo(). As 2 regexps can match the same URL, the regexp
+// responders are tested in the order they are registered. Registering
+// an already existing regexp responder (same method & same regexp
+// string) replaces its responder but does not change its position.
+//
+// See RegisterRegexpResponder() to directly pass a *regexp.Regexp.
 //
 // Example:
 // 		func TestFetchArticles(t *testing.T) {
@@ -526,11 +745,35 @@ func DeactivateAndReset() {
 // 			httpmock.RegisterResponder("GET", "/path/only",
 // 				httpmock.NewStringResponder("any host hello world", 200))
 //
-//			// requests to http://example.com/ will now return 'hello world' and
-//			// requests to any host with path /path/only will return 'any host hello world'
+// 			httpmock.RegisterResponder("GET", `=~^/item/id/\d+\z`,
+// 				httpmock.NewStringResponder("any item get", 200))
+//
+//			// requests to http://example.com/ will now return "hello world" and
+//			// requests to any host with path /path/only will return "any host hello world"
+//			// requests to any host with path matching ^/item/id/\d+\z regular expression will return "any item get"
 // 		}
 func RegisterResponder(method, url string, responder Responder) {
 	DefaultTransport.RegisterResponder(method, url, responder)
+}
+
+// RegisterRegexpResponder adds a new responder, associated with a given
+// HTTP method and URL (or path) regular expression.
+//
+// When a request comes in that matches, the responder will be called
+// and the response returned to the client.
+//
+// As 2 regexps can match the same URL, the regexp responders are
+// tested in the order they are registered. Registering an already
+// existing regexp responder (same method & same regexp string)
+// replaces its responder but does not change its position.
+//
+// A "=~" prefix is added to the stringified regexp in the statistics
+// returned by GetCallCountInfo().
+//
+// See RegisterResponder function and the "=~" prefix in its url
+// parameter to avoid compiling the regexp by yourself.
+func RegisterRegexpResponder(method string, urlRegexp *regexp.Regexp, responder Responder) {
+	DefaultTransport.RegisterRegexpResponder(method, urlRegexp, responder)
 }
 
 // RegisterResponderWithQuery it is same as RegisterResponder, but


### PR DESCRIPTION
See RegisterResponder() and "=~" prefix for its url parameter, and new
function/method RegisterRegexpResponder().

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>