### PR TITLE
Cosmetic - Use net/http package constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ func TestFetchArticles(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	// Exact URL match
-	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles",
-		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+	httpmock.RegisterResponder(http.MethodGet, "https://api.mybiz.com/articles",
+		httpmock.NewStringResponder(http.StatusOK, `[{"id": 1, "name": "My Great Article"}]`))
 
 	// Regexp match (could use httpmock.RegisterRegexpResponder instead)
-	httpmock.RegisterResponder("GET", `=~^https://api\.mybiz\.com/articles/id/\d+\z`,
-		httpmock.NewStringResponder(200, `{"id": 1, "name": "My Great Article"}`))
+	httpmock.RegisterResponder(http.MethodGet, `=~^https://api\.mybiz\.com/articles/id/\d+\z`,
+		httpmock.NewStringResponder(http.StatusOK, `{"id": 1, "name": "My Great Article"}`))
 
 	// do stuff that makes a request to articles
 	...
@@ -100,22 +100,22 @@ func TestFetchArticles(t *testing.T) {
 	articles := make([]map[string]interface{}, 0)
 
 	// mock to list out the articles
-	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.mybiz.com/articles",
 		func(req *http.Request) (*http.Response, error) {
-			resp, err := httpmock.NewJsonResponse(200, articles)
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, articles)
 			if err != nil {
-				return httpmock.NewStringResponse(500, ""), nil
+				return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
 			}
 			return resp, nil
 		},
 	)
 
 	// return an article related to the request with the help of regexp submatch (\d+)
-	httpmock.RegisterResponder("GET", `=~^https://api\.mybiz\.com/articles/id/(\d+)\z`,
+	httpmock.RegisterResponder(http.MethodGet, `=~^https://api\.mybiz\.com/articles/id/(\d+)\z`,
 		func(req *http.Request) (*http.Response, error) {
 			// Get ID from request
 			id := httpmock.MustGetSubmatchAsUint(req, 1) // 1=first regexp submatch
-			return httpmock.NewJsonResponse(200, map[string]interface{}{
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]interface{}{
 				"id":   id,
 				"name": "My Great Article",
 			})
@@ -123,18 +123,18 @@ func TestFetchArticles(t *testing.T) {
 	)
 
 	// mock to add a new article
-	httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles",
+	httpmock.RegisterResponder(http.MethodPost, "https://api.mybiz.com/articles",
 		func(req *http.Request) (*http.Response, error) {
 			article := make(map[string]interface{})
 			if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
-				return httpmock.NewStringResponse(400, ""), nil
+				return httpmock.NewStringResponse(http.StatusBadRequest, ""), nil
 			}
 
 			articles = append(articles, article)
 
-			resp, err := httpmock.NewJsonResponse(200, article)
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, article)
 			if err != nil {
-				return httpmock.NewStringResponse(500, ""), nil
+				return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
 			}
 			return resp, nil
 		},
@@ -194,8 +194,8 @@ import (
 
 var _ = Describe("Articles", func() {
 	It("returns a list of articles", func() {
-		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
-			httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mybiz.com/articles.json",
+			httpmock.NewStringResponder(http.StatusOK, `[{"id": 1, "name": "My Great Article"}]`))
 
 		// do stuff that makes a request to articles.json
 	})
@@ -238,9 +238,9 @@ import (
 var _ = Describe("Articles", func() {
 	It("returns a list of articles", func() {
 		fixture := `{"status":{"message": "Your message", "code": 200}}`
-		responder := httpmock.NewStringResponder(200, fixture)
+		responder := httpmock.NewStringResponder(http.StatusOK, fixture)
 		fakeUrl := "https://api.mybiz.com/articles.json"
-		httpmock.RegisterResponder("GET", fakeUrl, responder)
+		httpmock.RegisterResponder(http.MethodGet, fakeUrl, responder)
 
 		// fetch the article into struct
 		articleObject := &models.Article{}

--- a/doc.go
+++ b/doc.go
@@ -7,12 +7,12 @@ Simple Example:
   	defer httpmock.DeactivateAndReset()
 
   	// Exact URL match
-  	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles",
-  		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+  	httpmock.RegisterResponder(http.MethodGet, "https://api.mybiz.com/articles",
+  		httpmock.NewStringResponder(http.StatusOK, `[{"id": 1, "name": "My Great Article"}]`))
 
   	// Regexp match (could use httpmock.RegisterRegexpResponder instead)
-  	httpmock.RegisterResponder("GET", `=~^https://api\.mybiz\.com/articles/id/\d+\z`,
-  		httpmock.NewStringResponder(200, `{"id": 1, "name": "My Great Article"}`))
+  	httpmock.RegisterResponder(http.MethodGet, `=~^https://api\.mybiz\.com/articles/id/\d+\z`,
+  		httpmock.NewStringResponder(http.StatusOK, `{"id": 1, "name": "My Great Article"}`))
 
   	// do stuff that makes a request to articles
 
@@ -35,22 +35,22 @@ Advanced Example:
   	articles := make([]map[string]interface{}, 0)
 
   	// mock to list out the articles
-  	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles",
+  	httpmock.RegisterResponder(http.MethodGet, "https://api.mybiz.com/articles",
   		func(req *http.Request) (*http.Response, error) {
-  			resp, err := httpmock.NewJsonResponse(200, articles)
+  			resp, err := httpmock.NewJsonResponse(http.StatusOK, articles)
   			if err != nil {
-  				return httpmock.NewStringResponse(500, ""), nil
+  				return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
   			}
   			return resp, nil
   		},
   	)
 
   	// return an article related to the request with the help of regexp submatch (\d+)
-  	httpmock.RegisterResponder("GET", `=~^https://api\.mybiz\.com/articles/id/(\d+)\z`,
+  	httpmock.RegisterResponder(http.MethodGet, `=~^https://api\.mybiz\.com/articles/id/(\d+)\z`,
   		func(req *http.Request) (*http.Response, error) {
   			// Get ID from request
   			id := httpmock.MustGetSubmatchAsUint(req, 1) // 1=first regexp submatch
-  			return httpmock.NewJsonResponse(200, map[string]interface{}{
+  			return httpmock.NewJsonResponse(http.StatusOK, map[string]interface{}{
   				"id":   id,
   				"name": "My Great Article",
   			})
@@ -58,18 +58,18 @@ Advanced Example:
   	)
 
   	// mock to add a new article
-  	httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles",
+  	httpmock.RegisterResponder(http.MethodPost, "https://api.mybiz.com/articles",
   		func(req *http.Request) (*http.Response, error) {
   			article := make(map[string]interface{})
   			if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
-  				return httpmock.NewStringResponse(400, ""), nil
+  				return httpmock.NewStringResponse(http.StatusBadRequest, ""), nil
   			}
 
   			articles = append(articles, article)
 
-  			resp, err := httpmock.NewJsonResponse(200, article)
+  			resp, err := httpmock.NewJsonResponse(http.StatusOK, article)
   			if err != nil {
-  				return httpmock.NewStringResponse(500, ""), nil
+  				return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
   			}
   			return resp, nil
   		},

--- a/response.go
+++ b/response.go
@@ -58,8 +58,8 @@ func (r Responder) Once(fn ...func(...interface{})) Responder {
 //   ...
 //   func TestMyApp(t *testing.T) {
 //   	...
-//   	httpmock.RegisterResponder("GET", "/foo/bar",
-//    	httpmock.NewStringResponder(200, "{}").Trace(t.Log),
+//   	httpmock.RegisterResponder(http.MethodGet, "/foo/bar",
+//    	httpmock.NewStringResponder(http.StatusOK, "{}").Trace(t.Log),
 //   	)
 func (r Responder) Trace(fn func(...interface{})) Responder {
 	return func(req *http.Request) (*http.Response, error) {
@@ -189,9 +189,9 @@ func NewJsonResponder(status int, body interface{}) (Responder, error) { // noli
 // temporary variable and an error check, and so can be used as
 // NewStringResponder or NewBytesResponder in such context:
 //   RegisterResponder(
-//     "GET",
+//     http.MethodGet,
 //     "/test/path",
-//     NewJSONResponderOrPanic(200, &MyBody),
+//     NewJSONResponderOrPanic(http.StatusOK, &MyBody),
 //   )
 func NewJsonResponderOrPanic(status int, body interface{}) Responder { // nolint: golint
 	responder, err := NewJsonResponder(status, body)
@@ -229,9 +229,9 @@ func NewXmlResponder(status int, body interface{}) (Responder, error) { // nolin
 // temporary variable and an error check, and so can be used as
 // NewStringResponder or NewBytesResponder in such context:
 //   RegisterResponder(
-//     "GET",
+//     http.MethodGet,
 //     "/test/path",
-//     NewXmlResponderOrPanic(200, &MyBody),
+//     NewXmlResponderOrPanic(http.StatusOK, &MyBody),
 //   )
 func NewXmlResponderOrPanic(status int, body interface{}) Responder { // nolint: golint
 	responder, err := NewXmlResponder(status, body)

--- a/response_test.go
+++ b/response_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestResponderFromResponse(t *testing.T) {
-	responder := ResponderFromResponse(NewStringResponse(200, "hello world"))
+	responder := ResponderFromResponse(NewStringResponse(http.StatusOK, "hello world"))
 
 	req, err := http.NewRequest(http.MethodGet, testURL, nil)
 	if err != nil {
@@ -51,7 +51,7 @@ func TestResponderFromResponse(t *testing.T) {
 func TestNewNotFoundResponder(t *testing.T) {
 	responder := NewNotFoundResponder(func(args ...interface{}) {})
 
-	req, err := http.NewRequest("GET", "http://foo.bar/path", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://foo.bar/path", nil)
 	if err != nil {
 		t.Fatal("Error creating request")
 	}
@@ -94,7 +94,7 @@ func TestNewNotFoundResponder(t *testing.T) {
 
 func TestNewStringResponse(t *testing.T) {
 	body := "hello world"
-	status := 200
+	status := http.StatusOK
 	response := NewStringResponse(status, body)
 
 	data, err := ioutil.ReadAll(response.Body)
@@ -113,7 +113,7 @@ func TestNewStringResponse(t *testing.T) {
 
 func TestNewBytesResponse(t *testing.T) {
 	body := []byte("hello world")
-	status := 200
+	status := http.StatusOK
 	response := NewBytesResponse(status, body)
 
 	data, err := ioutil.ReadAll(response.Body)
@@ -136,7 +136,7 @@ func TestNewJsonResponse(t *testing.T) {
 	}
 
 	body := &schema{"world"}
-	status := 200
+	status := http.StatusOK
 
 	response, err := NewJsonResponse(status, body)
 	if err != nil {
@@ -167,7 +167,7 @@ func TestNewXmlResponse(t *testing.T) {
 	}
 
 	body := &schema{"world"}
-	status := 200
+	status := http.StatusOK
 
 	response, err := NewXmlResponse(status, body)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestNewErrorResponder(t *testing.T) {
 
 func TestRewindResponse(t *testing.T) {
 	body := []byte("hello world")
-	status := 200
+	status := http.StatusOK
 	responses := []*http.Response{
 		NewBytesResponse(status, body),
 		NewStringResponse(status, string(body)),

--- a/transport.go
+++ b/transport.go
@@ -386,14 +386,14 @@ func isRegexpURL(url string) bool {
 // 			httpmock.Activate()
 // 			defer httpmock.DeactivateAndReset()
 //
-// 			httpmock.RegisterResponder("GET", "http://example.com/",
-// 				httpmock.NewStringResponder(200, "hello world"))
+// 			httpmock.RegisterResponder(http.MethodGet, "http://example.com/",
+// 				httpmock.NewStringResponder(http.StatusOK, "hello world"))
 //
-// 			httpmock.RegisterResponder("GET", "/path/only",
-// 				httpmock.NewStringResponder("any host hello world", 200))
+// 			httpmock.RegisterResponder(http.MethodGet, "/path/only",
+// 				httpmock.NewStringResponder("any host hello world", http.StatusOK))
 //
-// 			httpmock.RegisterResponder("GET", `=~^/item/id/\d+\z`,
-// 				httpmock.NewStringResponder("any item get", 200))
+// 			httpmock.RegisterResponder(http.MethodGet, `=~^/item/id/\d+\z`,
+// 				httpmock.NewStringResponder("any item get", http.StatusOK))
 //
 // 			// requests to http://example.com/ will now return "hello world" and
 // 			// requests to any host with path /path/only will return "any host hello world"
@@ -578,7 +578,7 @@ func (m *MockTransport) Reset() {
 // As a special case, regexp responders generate 2 entries for each
 // call. One for the call caught and the other for the rule that
 // matched. For example:
-//   RegisterResponder("GET", `=~z\.com\z`, NewStringResponder(200, "body"))
+//   RegisterResponder(http.MethodGet, `=~z\.com\z`, NewStringResponder(http.StatusOK, "body"))
 //   http.Get("http://z.com")
 //
 // will generate the following result:
@@ -670,7 +670,7 @@ func ActivateNonDefault(client *http.Client) {
 // As a special case, regexp responders generate 2 entries for each
 // call. One for the call caught and the other for the rule that
 // matched. For example:
-//   RegisterResponder("GET", `=~z\.com\z`, NewStringResponder(200, "body"))
+//   RegisterResponder(http.MethodGet, `=~z\.com\z`, NewStringResponder(http.StatusOK, "body"))
 //   http.Get("http://z.com")
 //
 // will generate the following result:
@@ -751,14 +751,14 @@ func DeactivateAndReset() {
 // 			httpmock.Activate()
 // 			defer httpmock.DeactivateAndReset()
 //
-// 			httpmock.RegisterResponder("GET", "http://example.com/",
-// 				httpmock.NewStringResponder(200, "hello world"))
+// 			httpmock.RegisterResponder(http.MethodGet, "http://example.com/",
+// 				httpmock.NewStringResponder(http.StatusOK, "hello world"))
 //
-// 			httpmock.RegisterResponder("GET", "/path/only",
-// 				httpmock.NewStringResponder("any host hello world", 200))
+// 			httpmock.RegisterResponder(http.MethodGet, "/path/only",
+// 				httpmock.NewStringResponder("any host hello world", http.StatusOK))
 //
-// 			httpmock.RegisterResponder("GET", `=~^/item/id/\d+\z`,
-// 				httpmock.NewStringResponder("any item get", 200))
+// 			httpmock.RegisterResponder(http.MethodGet, `=~^/item/id/\d+\z`,
+// 				httpmock.NewStringResponder("any item get", http.StatusOK))
 //
 // 			// requests to http://example.com/ will now return "hello world" and
 // 			// requests to any host with path /path/only will return "any host hello world"
@@ -808,8 +808,8 @@ func RegisterRegexpResponder(method string, urlRegexp *regexp.Regexp, responder 
 // 				"a": []string{"3", "1", "8"},
 //				"b": []string{"4", "2"},
 //			}
-// 			httpmock.RegisterResponderWithQueryValues("GET", "http://example.com/", expectedQuery,
-// 				httpmock.NewStringResponder("hello world", 200))
+// 			httpmock.RegisterResponderWithQueryValues(http.MethodGet, "http://example.com/", expectedQuery,
+// 				httpmock.NewStringResponder("hello world", http.StatusOK))
 //
 //			// requests to http://example.com?a=1&a=3&a=8&b=2&b=4
 //			//      and to http://example.com?b=4&a=2&b=2&a=8&a=1
@@ -825,8 +825,8 @@ func RegisterRegexpResponder(method string, urlRegexp *regexp.Regexp, responder 
 //				"a": "1",
 //				"b": "2"
 //			}
-// 			httpmock.RegisterResponderWithQuery("GET", "http://example.com/", expectedQuery,
-// 				httpmock.NewStringResponder("hello world", 200))
+// 			httpmock.RegisterResponderWithQuery(http.MethodGet, "http://example.com/", expectedQuery,
+// 				httpmock.NewStringResponder("hello world", http.StatusOK))
 //
 //			// requests to http://example.com?a=1&b=2 and http://example.com?b=2&a=1 will now return 'hello world'
 // 		}
@@ -837,8 +837,8 @@ func RegisterRegexpResponder(method string, urlRegexp *regexp.Regexp, responder 
 // 			defer httpmock.DeactivateAndReset()
 //
 // 			expectedQuery := "a=3&b=4&b=2&a=1&a=8"
-// 			httpmock.RegisterResponderWithQueryValues("GET", "http://example.com/", expectedQuery,
-// 				httpmock.NewStringResponder("hello world", 200))
+// 			httpmock.RegisterResponderWithQueryValues(http.MethodGet, "http://example.com/", expectedQuery,
+// 				httpmock.NewStringResponder("hello world", http.StatusOK))
 //
 //			// requests to http://example.com?a=1&a=3&a=8&b=2&b=4
 //			//      and to http://example.com?b=4&a=2&b=2&a=8&a=1
@@ -882,13 +882,13 @@ var ErrSubmatchNotFound = errors.New("submatch not found")
 // RegisterRegexpResponder or RegisterResponder + "=~" URL prefix. It
 // allows to retrieve the n-th submatch of the matching regexp, as a
 // string. Example:
-// 	RegisterResponder("GET", `=~^/item/name/([^/]+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/name/([^/]+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			name, err := GetSubmatch(req, 1) // 1=first regexp submatch
 // 			if err != nil {
 // 				return nil, err
 // 			}
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   123,
 // 				"name": name,
 // 			})
@@ -913,13 +913,13 @@ func GetSubmatch(req *http.Request, n int) (string, error) {
 // RegisterRegexpResponder or RegisterResponder + "=~" URL prefix. It
 // allows to retrieve the n-th submatch of the matching regexp, as an
 // int64. Example:
-// 	RegisterResponder("GET", `=~^/item/id/(\d+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/id/(\d+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			id, err := GetSubmatchAsInt(req, 1) // 1=first regexp submatch
 // 			if err != nil {
 // 				return nil, err
 // 			}
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   id,
 // 				"name": "The beautiful name",
 // 			})
@@ -939,13 +939,13 @@ func GetSubmatchAsInt(req *http.Request, n int) (int64, error) {
 // RegisterRegexpResponder or RegisterResponder + "=~" URL prefix. It
 // allows to retrieve the n-th submatch of the matching regexp, as a
 // uint64. Example:
-// 	RegisterResponder("GET", `=~^/item/id/(\d+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/id/(\d+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			id, err := GetSubmatchAsUint(req, 1) // 1=first regexp submatch
 // 			if err != nil {
 // 				return nil, err
 // 			}
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   id,
 // 				"name": "The beautiful name",
 // 			})
@@ -971,7 +971,7 @@ func GetSubmatchAsUint(req *http.Request, n int) (uint64, error) {
 // 			if err != nil {
 // 				return nil, err
 // 			}
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":     id,
 // 				"name":   "The beautiful name",
 // 				"height": height,
@@ -993,10 +993,10 @@ func GetSubmatchAsFloat(req *http.Request, n int) (float64, error) {
 // installed by RegisterRegexpResponder or RegisterResponder + "=~"
 // URL prefix. It allows to retrieve the n-th submatch of the matching
 // regexp, as a string. Example:
-// 	RegisterResponder("GET", `=~^/item/name/([^/]+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/name/([^/]+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			name := MustGetSubmatch(req, 1) // 1=first regexp submatch
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   123,
 // 				"name": name,
 // 			})
@@ -1017,10 +1017,10 @@ func MustGetSubmatch(req *http.Request, n int) string {
 // RegisterRegexpResponder or RegisterResponder + "=~" URL prefix. It
 // allows to retrieve the n-th submatch of the matching regexp, as an
 // int64. Example:
-// 	RegisterResponder("GET", `=~^/item/id/(\d+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/id/(\d+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			id := MustGetSubmatchAsInt(req, 1) // 1=first regexp submatch
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   id,
 // 				"name": "The beautiful name",
 // 			})
@@ -1041,10 +1041,10 @@ func MustGetSubmatchAsInt(req *http.Request, n int) int64 {
 // RegisterRegexpResponder or RegisterResponder + "=~" URL prefix. It
 // allows to retrieve the n-th submatch of the matching regexp, as a
 // uint64. Example:
-// 	RegisterResponder("GET", `=~^/item/id/(\d+)\z`,
+// 	RegisterResponder(http.MethodGet, `=~^/item/id/(\d+)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			id, err := MustGetSubmatchAsUint(req, 1) // 1=first regexp submatch
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":   id,
 // 				"name": "The beautiful name",
 // 			})
@@ -1068,7 +1068,7 @@ func MustGetSubmatchAsUint(req *http.Request, n int) uint64 {
 // 	RegisterResponder("PATCH", `=~^/item/id/\d+\?height=(\d+(?:\.\d*)?)\z`,
 // 		func(req *http.Request) (*http.Response, error) {
 // 			height := MustGetSubmatchAsFloat(req, 1) // 1=first regexp submatch
-// 			return NewJsonResponse(200, map[string]interface{}{
+// 			return NewJsonResponse(http.StatusOK, map[string]interface{}{
 // 				"id":     id,
 // 				"name":   "The beautiful name",
 // 				"height": height,


### PR DESCRIPTION
Use constants defined in the net/http package to declare http methods and http status instead of using strings and ints.