### PR TITLE
Update response status to have expected contract

### DIFF
--- a/response.go
+++ b/response.go
@@ -21,7 +21,7 @@ func ResponderFromResponse(resp *http.Response) Responder {
 // an http status code.
 func NewStringResponse(status int, body string) *http.Response {
 	return &http.Response{
-		Status:     strconv.Itoa(status),
+		Status:     strconv.Itoa(status) + " " + http.StatusText(status),
 		StatusCode: status,
 		Body:       NewRespBodyFromString(body),
 		Header:     http.Header{},
@@ -37,7 +37,7 @@ func NewStringResponder(status int, body string) Responder {
 // an http status code.
 func NewBytesResponse(status int, body []byte) *http.Response {
 	return &http.Response{
-		Status:     strconv.Itoa(status),
+		Status:     strconv.Itoa(status) + " " + http.StatusText(status),
 		StatusCode: status,
 		Body:       NewRespBodyFromBytes(body),
 		Header:     http.Header{},


### PR DESCRIPTION
Contract should match: 
```
type Response struct {
	Status     string // e.g. "200 OK"
	StatusCode int    // e.g. 200
         ...
}
```
according to https://golang.org/src/net/http/response.go?s=731:4298#L25

#### Issue
https://github.com/jarcoal/httpmock/issues/83