### PR TITLE
ci: test against go1.17 + golangci-lint v1.43.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, tip]
+        go-version: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, tip]
         full-tests: [false]
         include:
-          - go-version: 1.16.x
+          - go-version: 1.17.x
             full-tests: true
 
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
         if: matrix.full-tests
         run: |
           curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |
-              sh -s -- -b $HOME/go/bin v1.37.1
+              sh -s -- -b $HOME/go/bin v1.43.0
           $HOME/go/bin/golangci-lint run --max-issues-per-linter 0 \
                                          --max-same-issues 0 \
                                          -E exportloopref \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easy mocking of http responses from external resources.
 
 ## Install
 
-Currently supports Go 1.7 - 1.16.
+Currently supports Go 1.7 - 1.17.
 
 `v1` branch has to be used instead of `master`.
 


### PR DESCRIPTION
Closes #109 