### PR TITLE
fix: be consistent between net/http and httpmock Response.Body

### DIFF
--- a/response.go
+++ b/response.go
@@ -458,15 +458,11 @@ func (d *dummyReadCloser) setup() {
 
 func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
 	d.setup()
-	n, err = d.body.Read(p)
-	if err == io.EOF {
-		d.body.Seek(0, 0) // nolint: errcheck
-	}
-	return n, err
+	return d.body.Read(p)
 }
 
 func (d *dummyReadCloser) Close() error {
 	d.setup()
-	d.body.Seek(0, 0) // nolint: errcheck
+	d.body.Seek(0, io.SeekEnd) // nolint: errcheck
 	return nil
 }


### PR DESCRIPTION
If some code wrongly depends on NewStringResponse() &
NewBytesResponse() response body be read ad infinitum, it should be
changed to either recall NewStringResponse() & NewBytesResponse()
before reading again the response body, or use NewBytesResponder() or
NewStringResponder().

Closes #108.