### PR TITLE
fix: url.RawPath is used instead of url.Path when checking path alone

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -135,7 +135,10 @@ func (m *MockTransport) findResponder(method string, url *url.URL) (
 
 		// if we weren't able to find a responder for the full URL, try with
 		// the path part only
-		pathAlone := url.Path
+		pathAlone := url.RawPath
+		if pathAlone == "" {
+			pathAlone = url.Path
+		}
 
 		// First with unsorted querystring: /path?q...
 		if hasQueryString {

--- a/transport_test.go
+++ b/transport_test.go
@@ -357,6 +357,15 @@ func TestMockTransportPathOnlyFallback(t *testing.T) {
 				testURL + "hello/world",
 			},
 		},
+		{
+			Responder: "/hello%2fworl%64",
+			Paths: []string{
+				testURL + "hello%2fworl%64?query=string&abc=zz#fragment",
+				testURL + "hello%2fworl%64?query=string&abc=zz",
+				testURL + "hello%2fworl%64#fragment",
+				testURL + "hello%2fworl%64",
+			},
+		},
 		// Regexp cases
 		{
 			Responder: `=~^http://.*/hello/.*ld\z`,


### PR DESCRIPTION
for consistency with full URL check, which is always unescaped.

Let 2 registered responders:
1. GET http://z.tld/foo%2fbar
2. GET /foo%2fbar

Before this commit:
- GET http://z.tld/foo%2fbar is caught by 1
- GET http://unknown.tld/foo%2fbar is *not* caught
  as the tested path is /foo/bar instead of /foo%2fbar

With this commit:
- GET http://z.tld/foo%2fbar is caught by 1
- GET http://unknown.tld/foo%2fbar is caught by 2

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>