### PR TITLE
NewBytesResponse and NewStringResponse sets ContentLength

### DIFF
--- a/response.go
+++ b/response.go
@@ -382,7 +382,7 @@ func NewStringResponse(status int, body string) *http.Response {
 		StatusCode:    status,
 		Body:          NewRespBodyFromString(body),
 		Header:        http.Header{},
-		ContentLength: -1,
+		ContentLength: int64(len(body)),
 	}
 }
 
@@ -408,7 +408,7 @@ func NewBytesResponse(status int, body []byte) *http.Response {
 		StatusCode:    status,
 		Body:          NewRespBodyFromBytes(body),
 		Header:        http.Header{},
-		ContentLength: -1,
+		ContentLength: int64(len(body)),
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -611,3 +611,20 @@ func TestParallelResponder(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+func TestResponseContentLength(t *testing.T) {
+	stringResponseBody := "body"
+	sr := NewStringResponse(200, stringResponseBody)
+
+	if sr.ContentLength != int64(len(stringResponseBody)) {
+		t.Fatal("NewStringResponse ContentLength was not set")
+	}
+
+	bytesResponseBody := []byte{0}
+	br := NewBytesResponse(200, bytesResponseBody)
+
+	if br.ContentLength != int64(len(bytesResponseBody)) {
+		t.Fatal("NewBytesResponse ContentLength was not set")
+	}
+
+}


### PR DESCRIPTION
See related issue: https://github.com/jarcoal/httpmock/pull/20#issuecomment-266199101

