### PR TITLE
fix: BodyContainsBytes & BodyContainsString used with And/Or

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -38,10 +38,6 @@ func (b *bodyCopyOnRead) Body() io.ReadCloser {
 	return b.body
 }
 
-func (b *bodyCopyOnRead) Buf() []byte {
-	return b.buf
-}
-
 func (b *bodyCopyOnRead) Rearm() {
 	b.rearm()
 }


### PR DESCRIPTION
Both "rearm" the body before (re-)reading it, so they can be used several times in a same matcher (combined with Or & And).

Closes #145.