### PR TITLE
Make http.Response.Status respect RFC 2616, like in Go stdlib.

### DIFF
--- a/response.go
+++ b/response.go
@@ -525,7 +525,7 @@ func NewNotFoundResponder(fn func(...any)) Responder {
 //	httpmock.NewStringResponse(200, httpmock.File("body.txt").String())
 func NewStringResponse(status int, body string) *http.Response {
 	return &http.Response{
-		Status:        strconv.Itoa(status),
+		Status:        fmt.Sprintf("%03d %s", status, http.StatusText(status)),
 		StatusCode:    status,
 		Body:          NewRespBodyFromString(body),
 		Header:        http.Header{},
@@ -551,7 +551,7 @@ func NewStringResponder(status int, body string) Responder {
 //	httpmock.NewBytesResponse(200, httpmock.File("body.raw").Bytes())
 func NewBytesResponse(status int, body []byte) *http.Response {
 	return &http.Response{
-		Status:        strconv.Itoa(status),
+		Status:        fmt.Sprintf("%03d %s", status, http.StatusText(status)),
 		StatusCode:    status,
 		Body:          NewRespBodyFromBytes(body),
 		Header:        http.Header{},

--- a/response_test.go
+++ b/response_test.go
@@ -712,7 +712,7 @@ func TestResponder_HeaderAddSet(t *testing.T) {
 
 	orig := httpmock.NewStringResponder(200, "body")
 	origNilHeader := httpmock.ResponderFromResponse(&http.Response{
-		Status:        "200",
+		Status:        "200 OK",
 		StatusCode:    200,
 		Body:          httpmock.NewRespBodyFromString("body"),
 		ContentLength: -1,


### PR DESCRIPTION
Although RFC 2616 has been superseded with RFC 9110, some client implementation still rely on certain behavious regarding the Status-Line.

Now, as httpmock currently implements it, per [RFC 9110#6.2-1](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.2-1), the "reason phrase" is actually optional, and you need only to include the status code.

Back in the days of [RFC 2616#6.1](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1), the Status-Line had to contain both the status code (eg. 200) and its textual representation (eg. OK).

Change code is directly stolen from the Go standard library.

This aims to fix #83 .