### PR TITLE
docs: update resty example

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ var _ = Describe("Articles", func() {
   It("returns a list of articles", func() {
     fixture := `{"status":{"message": "Your message", "code": 200}}`
     // have to use JsonResponder to get a content-type header application/json
-    // alternately, create a go object instead of using json.RawMessage
+    // alternatively, create a go object instead of using json.RawMessage
     responder, _ := httpmock.NewJsonResponder(200, json.RawMessage(`{"status":{"message": "Your message", "code": 200}}`)
     fakeUrl := "https://api.mybiz.com/articles.json"
     httpmock.RegisterResponder("GET", fakeUrl, responder)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ type Article struct {
 var _ = Describe("Articles", func() {
   It("returns a list of articles", func() {
     fixture := `{"status":{"message": "Your message", "code": 200}}`
-    // have to use JsonResponder to get a content-type header application/json
+    // have to use NewJsonResponder to get an application/json content-type
     // alternatively, create a go object instead of using json.RawMessage
     responder, _ := httpmock.NewJsonResponder(200, json.RawMessage(`{"status":{"message": "Your message", "code": 200}}`)
     fakeUrl := "https://api.mybiz.com/articles.json"


### PR DESCRIPTION
Fixes #150.
- Switches the example to use resty/v2, which no longer supports resty.DefaultClient
- Uses a global client instead, which seems to be required in a case like this because `resty.New()` creates a new transport every time it is called
- Uses a json responder instead of a text responder to set the content-type header correctly, as referenced in https://github.com/jarcoal/httpmock/issues/150#issuecomment-2032431445