### PR TITLE
Avoid data race when closing body

### DIFF
--- a/response.go
+++ b/response.go
@@ -740,8 +740,8 @@ type lenReadSeeker interface {
 
 type dummyReadCloser struct {
 	orig any           // string or []byte
+	mu   sync.Mutex    // protects operations over body
 	body lenReadSeeker // instanciated on demand from orig
-	mu   sync.Mutex
 }
 
 // copy returns a new instance resetting d.body to nil.
@@ -767,6 +767,9 @@ func (d *dummyReadCloser) setup() {
 }
 
 func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.setup()
 	return d.body.Read(p)
 }
@@ -781,6 +784,9 @@ func (d *dummyReadCloser) Close() error {
 }
 
 func (d *dummyReadCloser) Len() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.setup()
 	return d.body.Len()
 }

--- a/response.go
+++ b/response.go
@@ -741,6 +741,7 @@ type lenReadSeeker interface {
 type dummyReadCloser struct {
 	orig any           // string or []byte
 	body lenReadSeeker // instanciated on demand from orig
+	mu   sync.Mutex
 }
 
 // copy returns a new instance resetting d.body to nil.
@@ -771,6 +772,9 @@ func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
 }
 
 func (d *dummyReadCloser) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.setup()
 	d.body.Seek(0, io.SeekEnd) //nolint: errcheck
 	return nil


### PR DESCRIPTION
Some libraries which use http client call `resp.Body.Close()` multiple times from different goroutines, which leads to data race in tests because `Close` performa some mutations under the hood.
I understand this is mistake in those libraries, but real implementation in net/http doesn't produce data race is same condition. So I believe httmock should not as well.